### PR TITLE
Initialize headers

### DIFF
--- a/lib/openshift_client.rb
+++ b/lib/openshift_client.rb
@@ -23,6 +23,7 @@ module OpenshiftClient
     def initialize(uri, version = 'v1beta1')
       handle_uri(uri, '/osapi')
       @api_version = version
+      @headers = {}
       ssl_options
     end
 

--- a/lib/openshift_client/version.rb
+++ b/lib/openshift_client/version.rb
@@ -1,4 +1,4 @@
 # Openshift REST-API Client
 module OpenshiftClient
-  VERSION = '0.0.5'
+  VERSION = '0.0.6'
 end

--- a/openshift_client.gemspec
+++ b/openshift_client.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest'
   spec.add_development_dependency 'webmock'
   spec.add_development_dependency 'rubocop', '= 0.30.0'
-  spec.add_dependency 'kubeclient', '>= 0.1.14'
+  spec.add_dependency 'kubeclient', '>= 0.1.17'
   spec.add_dependency 'activesupport'
   spec.add_dependency 'recursive-open-struct', '= 0.6.1'
 end


### PR DESCRIPTION
Fix a bug introduced in kubeclient-0.1.17, which requires the
initialization of headers variable.
