### PR TITLE
Default path should be absolute

### DIFF
--- a/lib/openshift_client.rb
+++ b/lib/openshift_client.rb
@@ -20,7 +20,7 @@ module OpenshiftClient
       [OpenshiftClient.const_set(et, Class.new(RecursiveOpenStruct)), et]
     end
 
-    def initialize(uri, version = 'v1', path = 'oapi')
+    def initialize(uri, version = 'v1', path = '/oapi')
       handle_uri(uri, path)
       @api_version = version
       @headers = {}

--- a/lib/openshift_client/version.rb
+++ b/lib/openshift_client/version.rb
@@ -1,4 +1,4 @@
 # Openshift REST-API Client
 module OpenshiftClient
-  VERSION = '0.0.7'
+  VERSION = '0.0.8'
 end

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -6,4 +6,10 @@ class TestClient < MiniTest::Test
     client = OpenshiftClient::Client.new 'https://localhost:8080/oapi'
     assert_equal(true, client.respond_to?('api_valid?'))
   end
+
+  def test_path_valid
+    uri = URI::HTTPS.build(host: 'localhost', port: 8080)
+    client2 = OpenshiftClient::Client.new uri
+    assert_equal(true, client2.respond_to?('api_valid?'))
+  end
 end


### PR DESCRIPTION
Fix a bug introduced in 0b3d8b2e3dedab64f3df21528807887117e4c21b.
The default path in openshift client ctor must be an absolute path.
