### PR TITLE
Include HTTP Proxy Wrapper

### DIFF
--- a/lib/openshift_client.rb
+++ b/lib/openshift_client.rb
@@ -4,6 +4,7 @@ require 'kubeclient/entity_list'
 require 'kubeclient/kube_exception'
 require 'kubeclient/watch_notice'
 require 'kubeclient/watch_stream'
+require 'kubeclient/http_proxy_wrapper'
 require 'kubeclient/common'
 
 module OpenshiftClient


### PR DESCRIPTION
As HTTP Proxy Wrapper was added to kubeclient, the openshift client
should include the new class file as well.
