### PR TITLE
Bumping version to 1.1.0

### DIFF
--- a/lib/openshift_client/version.rb
+++ b/lib/openshift_client/version.rb
@@ -1,4 +1,4 @@
 # Openshift REST-API Client
 module OpenshiftClient
-  VERSION = '1.0.0'
+  VERSION = '1.1.0'
 end


### PR DESCRIPTION
@abonas releasing a new version is required to take advantage of latest kubeclient (dependency bump was committed already).
