### PR TITLE
Updating the ruby versions tested in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: ruby
 rvm:
-  - "2.0"
-  - "2.1"
-  - "2.2"
+  - "2.2.2"
   - "2.3.0"
 sudo: false
 cache: bundler


### PR DESCRIPTION
Installing rest-client 2.0.0 during travis tests in #27 raises an error, it seems that ruby version >= 2.2.2 is required. 
