### PR TITLE
Add support for processing templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ TODO: Write usage instructions here
 Initialize the client:
 client = OpenshiftClient::Client.new 'https://hostName:8443'
 
+#### Process a template
+Returns a processed template containing a list of objects to create.
+Input parameter - template (hash)
+Besides its metadata, the template should include a list of objects to be processed and a list of parameters
+to be substituted. Note that for a required parameter that does not provide a generated value, you must supply a value.
+
+```ruby
+client.process_template template
+```
+
 ## Contributing
 
 1. Fork it ( https://github.com/[my-github-username]/openshift_client/fork )

--- a/lib/openshift_client.rb
+++ b/lib/openshift_client.rb
@@ -52,5 +52,16 @@ module OpenshiftClient
     def all_entities
       retrieve_all_entities(ENTITY_TYPES)
     end
+
+    def process_template(template)
+      ns_prefix = build_namespace_prefix(template[:metadata][:namespace])
+      @headers['Content-Type'] = 'application/json'
+      response = handle_exception do
+        rest_client[ns_prefix + 'processedtemplates']
+        .post(template.to_h.to_json, @headers)
+      end
+      result = JSON.parse(response)
+      result
+    end
   end
 end

--- a/test/json/processed_template.json
+++ b/test/json/processed_template.json
@@ -1,0 +1,27 @@
+{
+  "kind": "Template",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "my-template",
+    "namespace": "default",
+    "selfLink": "/oapi/v1/namespaces/default/processedtemplates/my-template",
+    "uid": "2240c61c-8f70-11e5-a806-001a4a231290",
+    "resourceVersion": "1399",
+    "creationTimestamp": "2015-11-20T10:19:07Z"
+  },
+  "objects": [
+    {
+      "apiVersion": "v1",
+      "kind": "Service",
+      "metadata": {
+        "name": "test/my-service"
+      }
+    }
+  ],
+  "parameters": [
+    {
+      "name": "NAME_PREFIX",
+      "value": "test/"
+    }
+  ]
+}

--- a/test/test_process_template.rb
+++ b/test/test_process_template.rb
@@ -1,0 +1,44 @@
+require 'test_helper'
+
+# Process Template tests
+class TestProcessTemplate < MiniTest::Test
+  def test_process_template
+    client = OpenshiftClient::Client.new 'https://localhost:8080'
+    template = {}
+    template[:metadata] = {}
+    template[:metadata][:name] = 'my-template'
+    template[:metadata][:namespace] = 'default'
+    template[:kind] = 'Template'
+    template[:apiVersion] = 'v1'
+    service = {}
+    service[:metadata] = {}
+    service[:metadata][:name] = '${NAME_PREFIX}my-service'
+    service[:kind] = 'Service'
+    service[:apiVersion] = 'v1'
+    template[:objects] = [service]
+    param = { name: 'NAME_PREFIX', value: 'test/' }
+    template[:parameters] = [param]
+
+    req_body = "{\"metadata\":{\"name\":\"my-template\",\"namespace\":\"default\"},"\
+    "\"kind\":\"Template\",\"apiVersion\":\"v1\",\"objects\":[{\"metadata\":"\
+    "{\"name\":\"${NAME_PREFIX}my-service\"},\"kind\":\"Service\",\"apiVersion\":\"v1\"}],"\
+    "\"parameters\":[{\"name\":\"NAME_PREFIX\",\"value\":\"test/\"}]}"
+
+    expected_url = 'https://localhost:8080/oapi/v1/namespaces/default/processedtemplates'
+    stub_request(:post, expected_url)
+      .with(body: req_body, headers: { 'Content-Type' => 'application/json' })
+      .to_return(body: open_test_file('processed_template.json'), status: 200)
+
+    processed_template = client.process_template_kc template
+
+    assert_equal('test/my-service', processed_template['objects'].first['metadata']['name'])
+
+    assert_requested(:post, expected_url, times: 1) do |req|
+      data = JSON.parse(req.body)
+      data['kind'] == 'Template' &&
+        data['apiVersion'] == 'v1' &&
+        data['metadata']['name'] == 'my-template' &&
+        data['metadata']['namespace'] == 'default'
+    end
+  end
+end


### PR DESCRIPTION
This PR adds support for processing templates. 
A template allows the user to generate a list of objects with certain labels and parameters. This list can be then used in order to create these objects. So, we would like to support processing the template and return the list of objects to create (as part of the processed template). 
Relevant Openshift docs [here](https://docs.openshift.com/enterprise/3.2/dev_guide/templates.html#generating-a-list-of-objects).
@abonas @simon3z @zeari 
